### PR TITLE
Emit console.trace instead of throwing errors for non-critical stuff

### DIFF
--- a/RandomTips.js
+++ b/RandomTips.js
@@ -294,8 +294,8 @@ export function setContext(newContext) {
 export async function showRandomTip() {
     // only try to select tip, if one is even available
     if (tips.length === 0) {
-        console.info("no tips to show available anymore");
-        return Promise.reject(new Error("no tips to show available anymore"));
+        console.trace("no tips to show available anymore");
+        return;
     }
 
     // randomly select element
@@ -322,15 +322,15 @@ export async function showRandomTip() {
  * Shows the random tip only randomly so the user is not annoyed.
  *
  * @public
- * @returns {Promise}
+ * @returns {Promise | undefined}
  */
 export function showRandomTipIfWanted() {
     saveConfig();
 
     // randomize tip showing in general
     if (!randomizePassed(GLOBAL_RANDOMIZE)) {
-        console.info("show no random tip, because randomize did not pass");
-        return Promise.reject(new Error("show no random tip, because randomize did not pass"));
+        console.trace("show no random tip, because randomize did not pass");
+        return;
     }
 
     return showRandomTip();


### PR DESCRIPTION
Fixes https://github.com/TinyWebEx/RandomTips/issues/7

The issue is here that a promise is usually expected, so I cannot just return
Promise.ject() with an empty error, because this also results in a red error
for the promise (with the worse error message "undefined").

Thus I've just made it to return a successful promise or undefined.

I've also changed the similar uncritical error when tips should be shown
according to gobal randomize, but no tip could be shown due to other factors,
so there is no tip to be shown.

Console.trace is BTW well-supported across browsers:
https://developer.mozilla.org/en-US/docs/Web/API/console/trace#browser_compatibility